### PR TITLE
feat: Refactor to accept `callback_url` instead of `port`

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -52,7 +52,7 @@ pub struct Arguments {
         default_value = "http://localhost:8081",
         env = "DOKEN_CALLBACK_URL"
     )]
-    pub callback_url: Option<String>,
+    pub callback_url: String,
 
     /// OAuth 2.0 Client Identifier https://www.rfc-editor.org/rfc/rfc6749#section-2.2
     #[clap(long, env = "DOKEN_CLIENT_ID")]

--- a/src/args.rs
+++ b/src/args.rs
@@ -47,16 +47,16 @@ pub struct Arguments {
     pub discovery_url: Option<String>,
 
     /// Callback URL that's been set for your application
-    #[clap(long, env = "DOKEN_CALLBACK_URL")]
+    #[clap(
+        long,
+        default_value = "http://localhost:8081",
+        env = "DOKEN_CALLBACK_URL"
+    )]
     pub callback_url: Option<String>,
 
     /// OAuth 2.0 Client Identifier https://www.rfc-editor.org/rfc/rfc6749#section-2.2
     #[clap(long, env = "DOKEN_CLIENT_ID")]
     pub client_id: String,
-
-    /// Port for callback url
-    #[clap(long, default_value_t = 8081, env = "DOKEN_PORT")]
-    pub port: u16,
 
     /// OAuth 2.0 Client Secret. Please use `--client-secret-stdin`, because it's not get stored in a shell history.  https://www.rfc-editor.org/rfc/rfc6749#section-2.3.1
     #[clap(long, env = "DOKEN_CLIENT_SECRET")]

--- a/src/args.rs
+++ b/src/args.rs
@@ -46,6 +46,10 @@ pub struct Arguments {
     #[clap(long, env = "DOKEN_DISCOVERY_URL")]
     pub discovery_url: Option<String>,
 
+    /// Callback URL that's been set for your application
+    #[clap(long, env = "DOKEN_CALLBACK_URL")]
+    pub callback_url: Option<String>,
+
     /// OAuth 2.0 Client Identifier https://www.rfc-editor.org/rfc/rfc6749#section-2.2
     #[clap(long, env = "DOKEN_CLIENT_ID")]
     pub client_id: String,

--- a/src/auth_server.rs
+++ b/src/auth_server.rs
@@ -22,7 +22,9 @@ pub struct AuthServer {
 }
 
 impl AuthServer {
-    pub fn new(port: u16) -> Result<AuthServer> {
+    pub fn new(callback_url: &str) -> Result<AuthServer> {
+        let url = Url::parse(callback_url)?;
+        let port = url.port_or_known_default().unwrap();
         log::debug!("Creating http server on port {}", port);
         let server = TinyServer::http(format!("127.0.0.1:{}", port))
             .map_err(|e| anyhow!(e))

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ mod args;
 mod auth_server;
 mod file_state;
 mod oauth_client;
+mod open_authorization_url;
 mod openidc_discovery;
 mod retrievers;
 mod token_info;

--- a/src/oauth_client.rs
+++ b/src/oauth_client.rs
@@ -20,14 +20,6 @@ impl<'a> OAuthClient<'a> {
         token_url: &str,
         authorization_url: &str,
     ) -> Result<BasicClient> {
-        let port = args.port;
-
-        let redirect_url = if port == 80 {
-            "http://localhost".to_owned()
-        } else {
-            format!("http://localhost:{}", port)
-        };
-
         Ok(BasicClient::new(
             ClientId::new(args.client_id.to_owned()),
             args.client_secret.clone().map(ClientSecret::new),
@@ -44,7 +36,7 @@ impl<'a> OAuthClient<'a> {
                 )
             })?),
         )
-        .set_redirect_uri(RedirectUrl::new(redirect_url).unwrap()))
+        .set_redirect_uri(RedirectUrl::new(args.callback_url.to_owned()).unwrap()))
     }
 
     pub async fn new(args: &Arguments) -> Result<OAuthClient> {

--- a/src/open_authorization_url/mod.rs
+++ b/src/open_authorization_url/mod.rs
@@ -1,0 +1,19 @@
+use anyhow::Result;
+use std::process::Command;
+
+pub fn open_authorization_url<'a>(url: &str, callback_url: &str) -> Result<()> {
+    log::debug!(
+        "Using `{}` url to initiate user session. Callback url is: {}",
+        url,
+        callback_url
+    );
+
+    log::debug!("Opening a browser with {url} ...");
+    let status = Command::new("open").arg(url).status()?;
+
+    if !status.success() {
+        panic!("Url couldn't be opened.")
+    }
+
+    Ok(())
+}

--- a/src/open_authorization_url/mod.rs
+++ b/src/open_authorization_url/mod.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use std::process::Command;
 
-pub fn open_authorization_url<'a>(url: &str, callback_url: &str) -> Result<()> {
+pub fn open_authorization_url(url: &str, callback_url: &str) -> Result<()> {
     log::debug!(
         "Using `{}` url to initiate user session. Callback url is: {}",
         url,

--- a/src/retrievers/authorization_code_with_pkce_retriever.rs
+++ b/src/retrievers/authorization_code_with_pkce_retriever.rs
@@ -1,11 +1,11 @@
 use crate::args::Arguments;
 use crate::auth_server::AuthServer;
 use crate::oauth_client::OAuthClient;
+use crate::open_authorization_url::open_authorization_url;
 use crate::token_info::TokenInfo;
 use anyhow::Result;
 use async_trait::async_trait;
 use oauth2::PkceCodeChallenge;
-use std::process::Command;
 
 use super::token_retriever::TokenRetriever;
 
@@ -29,16 +29,9 @@ impl<'a> TokenRetriever for AuthorizationCodeWithPKCERetriever<'a> {
         let (pkce_challenge, pkce_verifier) = PkceCodeChallenge::new_random_sha256();
 
         let (url, csrf) = self.oauth_client.authorize_url(Some(pkce_challenge));
-        log::debug!("Using `{}` url to initiate user session", url);
+        open_authorization_url(url.as_str(), &self.args.callback_url)?;
 
-        log::debug!("Opening a browser with {url}...");
-        let status = Command::new("open").arg(url.as_str()).status()?;
-
-        if !status.success() {
-            panic!("Url couldn't be opened.")
-        }
-
-        let code = AuthServer::new(self.args.port)?
+        let code = AuthServer::new(&self.args.callback_url)?
             .get_code(self.args.timeout, csrf)
             .await?;
 

--- a/src/retrievers/implicit_retriever.rs
+++ b/src/retrievers/implicit_retriever.rs
@@ -1,10 +1,10 @@
 use crate::args::Arguments;
 use crate::auth_server::AuthServer;
+use crate::open_authorization_url::open_authorization_url;
 use crate::token_info::TokenInfo;
 use crate::OAuthClient;
 use anyhow::Result;
 use async_trait::async_trait;
-use std::process::Command;
 
 use super::token_retriever::TokenRetriever;
 
@@ -27,14 +27,9 @@ impl<'a> TokenRetriever for ImplicitRetriever<'a> {
     async fn retrieve(&self) -> Result<TokenInfo> {
         let (url, csrf) = self.oauth_client.implicit_url();
 
-        log::debug!("Opening a browser with {url} ...");
-        let status = Command::new("open").arg(url.as_str()).status()?;
+        open_authorization_url(url.as_str(), &self.args.callback_url)?;
 
-        if !status.success() {
-            panic!("Url couldn't be opened.")
-        }
-
-        AuthServer::new(self.args.port)?
+        AuthServer::new(&self.args.callback_url)?
             .get_token_data(self.args.timeout, csrf)
             .await
     }


### PR DESCRIPTION
Allows to more flexibly set a `callback_url` that can consist of:
* custom domain `http://my_app_domain.com`
* custom port `http://localhost:8080`
* custom protocol `https://my_domain.com`