### PR TITLE
feat: Adjust size of the browser during initial open

### DIFF
--- a/src/auth_browser.rs
+++ b/src/auth_browser.rs
@@ -86,7 +86,6 @@ impl AuthBrowser {
         let handle = tokio::spawn(async move {
             while let Some(h) = handler.next().await {
                 if h.is_err() {
-                    // TODO: Detect that user has closed a browser. Fail immediately
                     log::error!("Handler created an error");
                     break;
                 }

--- a/src/auth_browser.rs
+++ b/src/auth_browser.rs
@@ -70,6 +70,9 @@ impl AuthBrowser {
             BrowserConfig::builder()
                 .with_head()
                 .enable_request_intercept()
+                .window_size(800, 600)
+                .respect_https_errors()
+                .enable_cache()
                 .build()
                 .map_err(|e| anyhow!(e))?,
         )

--- a/src/auth_browser.rs
+++ b/src/auth_browser.rs
@@ -72,9 +72,11 @@ impl AuthBrowser {
         let (tx_browser, rx_browser) = oneshot::channel();
 
         log::debug!("Opening chromium instance");
-        let mut viewport = Viewport::default();
-        viewport.width = 800;
-        viewport.height = 1000;
+        let viewport = Viewport {
+            width: 800,
+            height: 1000,
+            ..Viewport::default()
+        };
         let (mut browser, mut handler) = Browser::launch(
             BrowserConfig::builder()
                 .with_head()


### PR DESCRIPTION
Changes the default size of the browser to 800x600 pixels.

Adds reuse of first tab to not bother people with the first one.

Adds a handler for the browser closed by the user.

Fix issue with incorrect error message after timeout.